### PR TITLE
Port LootRestock

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ CurseForge: https://curseforge.com/minecraft/mc-mods/lootrestock
 - Configurable cooldown period using simple time units (e.g. `7 days`, `12 hours`, `30 minutes`)
 - Persists data across server restarts
 - Optionally reset only when chests are empty (or always) after timeout expires
+- Shows players an action-bar reminder that loot chests restock and should be left in place unless removal is needed
+- Supports protected chest breaking with optional crouch-and-hold removal
 
 ## Performance Design
 LootRestock is designed with server performance in mind:
@@ -33,6 +35,9 @@ reset_time_value=7
 reset_time_unit=days
 only_reset_when_empty=true
 include_barrels=false
+allow_chest_breaking=op_only
+require_crouch_to_break=true
+crouch_break_seconds=4
 ```
 
 - `reset_time_value`: Number of time units before a chest is eligible for reset
@@ -41,6 +46,9 @@ include_barrels=false
   - `true`: Chests will reset only if empty (after the cooldown)
   - `false`: Chests will reset regardless of contents (after the cooldown)
 - `include_barrels`: Whether barrel loot should get reset (default value: `false`)
+- `allow_chest_breaking`: Who can remove restocking containers: `op_only`, `anyone`, or `no_one`
+- `require_crouch_to_break`: Whether permitted players must crouch to remove restocking containers
+- `crouch_break_seconds`: Extra hold time required while crouching before a restocking container can be removed
 
 ## Data Persistence
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'net.fabricmc.fabric-loom-remap' version "${loom_version}"
+	id 'net.fabricmc.fabric-loom' version "${loom_version}"
 	id 'maven-publish'
 }
 
@@ -33,11 +33,10 @@ loom {
 dependencies {
 	// To change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings loom.officialMojangMappings()
-	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+	implementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
+	implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
 	
 }
 
@@ -49,8 +48,12 @@ processResources {
 	}
 }
 
+def targetJavaVersion = 25
 tasks.withType(JavaCompile).configureEach {
-	it.options.release = 21
+	it.options.encoding = "UTF-8"
+	if (targetJavaVersion >= 10 || JavaVersion.current().isJava10Compatible()) {
+		it.options.release.set(targetJavaVersion)
+	}
 }
 
 java {
@@ -59,8 +62,10 @@ java {
 	// If you remove this line, sources will not be generated.
 	withSourcesJar()
 
-	sourceCompatibility = JavaVersion.VERSION_21
-	targetCompatibility = JavaVersion.VERSION_21
+	def javaVersion = JavaVersion.toVersion(targetJavaVersion)
+	if (JavaVersion.current() < javaVersion) {
+		toolchain.languageVersion = JavaLanguageVersion.of(targetJavaVersion)
+	}
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,14 +7,14 @@ org.gradle.configuration-cache=false
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.11
-loader_version=0.18.4
-loom_version=1.15-SNAPSHOT
+minecraft_version=26.2
+loader_version=0.19.3
+loom_version=1.16-SNAPSHOT
 
 # Mod Properties
-mod_version=1.0.0
-maven_group=com.example
-archives_base_name=template-mod
+mod_version=26.2
+maven_group=org.oldskooler
+archives_base_name=lootrestock
 
 # Dependencies
-fabric_api_version=0.141.2+1.21.11
+fabric_api_version=0.152.1+26.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/org/oldskooler/lootrestock/LootRestock.java
+++ b/src/main/java/org/oldskooler/lootrestock/LootRestock.java
@@ -3,15 +3,18 @@ package org.oldskooler.lootrestock;
  import net.fabricmc.api.ModInitializer;
  import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
  import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
+ import net.fabricmc.fabric.api.event.player.AttackBlockCallback;
  import net.fabricmc.fabric.api.event.player.AttackEntityCallback;
  import net.fabricmc.fabric.api.event.player.PlayerBlockBreakEvents;
  import net.fabricmc.fabric.api.event.player.UseBlockCallback;
  import net.fabricmc.fabric.api.event.player.UseEntityCallback;
 import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.permissions.Permissions;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.world.Containers;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.vehicle.minecart.MinecartChest;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.BarrelBlock;
@@ -26,6 +29,10 @@ import org.oldskooler.lootrestock.config.ModConfig;
  import org.oldskooler.lootrestock.handler.ChestResetHandler;
  import org.slf4j.Logger;
  import org.slf4j.LoggerFactory;
+
+ import java.util.HashMap;
+ import java.util.Map;
+ import java.util.UUID;
 
  /**
  * LootRestock is a Fabric mod that tracks and resets lootable chests
@@ -49,6 +56,7 @@ public class LootRestock implements ModInitializer {
     private ChestResetHandler resetHandler;
 
     private long tickCounter = 0;
+    private final Map<BreakAttemptKey, Long> protectedBreakAttempts = new HashMap<>();
 
     @Override
     public void onInitialize() {
@@ -70,6 +78,9 @@ public class LootRestock implements ModInitializer {
             if (!world.isClientSide() && hitResult.getType() == HitResult.Type.BLOCK) {
                 BlockPos pos = hitResult.getBlockPos();
                 registerBlockInteraction(world, pos);
+                if (isRestockingContainer(world, pos)) {
+                    sendActionBar(player, getRestockNotice());
+                }
             }
             return InteractionResult.PASS;
         });
@@ -78,30 +89,68 @@ public class LootRestock implements ModInitializer {
         UseEntityCallback.EVENT.register((player, world, hand, entity, hitResult) -> {
             if (!world.isClientSide()) {
                 registerEntityInteraction(world, entity);
+                if (isRestockingMinecart(world, entity)) {
+                    sendActionBar(player, getRestockNotice());
+                }
             }
+            return InteractionResult.PASS;
+        });
+
+        // Register block attack callback to start the longer crouch-break timer.
+        AttackBlockCallback.EVENT.register((player, world, hand, pos, direction) -> {
+            if (!world.isClientSide() && isRestockingContainer(world, pos)) {
+                BreakDecision decision = getBreakDecision(player);
+                if (!decision.canBreak()) {
+                    protectedBreakAttempts.remove(BreakAttemptKey.block(player, world, pos));
+                    sendActionBar(player, decision.message());
+                    return InteractionResult.FAIL;
+                }
+
+                BreakAttemptKey key = BreakAttemptKey.block(player, world, pos);
+                protectedBreakAttempts.putIfAbsent(key, System.currentTimeMillis());
+
+                if (config.requireCrouchToBreak() && config.getCrouchBreakMs() > 0) {
+                    sendActionBar(player, "Keep crouching to remove this restocking chest.");
+                }
+            }
+
             return InteractionResult.PASS;
         });
 
         // Register block destroy interaction callback
         PlayerBlockBreakEvents.BEFORE.register((world, player, pos, state, blockEntity) -> {
-            if (!world.isClientSide() && blockEntity instanceof RandomizableContainerBlockEntity chestBlockEntity) {
+            if (!world.isClientSide() && isRestockingContainer(world, pos, blockEntity)) {
                 boolean isTracked = this.dataManager.isTracked(world, pos);
-                
-                if (isTracked || chestBlockEntity.getLootTable() != null) {
-                    // Add it to tracked list if not already
-                    if (!isTracked) {
-                        registerBlockInteraction(world, pos);
-                    }
 
-                    // Drop the inventory contents naturally
-                    Containers.dropContents(world, pos, chestBlockEntity);
+                if (!isTracked) {
+                    registerBlockInteraction(world, pos);
+                }
 
-                    // Prevent from actually breaking
+                BreakDecision decision = getBreakDecision(player);
+                if (!decision.canBreak()) {
+                    protectedBreakAttempts.remove(BreakAttemptKey.block(player, world, pos));
+                    sendActionBar(player, decision.message());
                     return false;
                 }
+
+                BreakAttemptKey key = BreakAttemptKey.block(player, world, pos);
+                long startedAt = protectedBreakAttempts.computeIfAbsent(key, ignored -> System.currentTimeMillis());
+                long elapsedMs = System.currentTimeMillis() - startedAt;
+                if (config.requireCrouchToBreak() && elapsedMs < config.getCrouchBreakMs()) {
+                    long remainingSeconds = Math.max(1L, (config.getCrouchBreakMs() - elapsedMs + 999L) / 1000L);
+                    sendActionBar(player, "Keep crouching for " + remainingSeconds + "s to remove this restocking chest.");
+                    return false;
+                }
+
+                return true;
             }
 
             return true;
+        });
+
+        PlayerBlockBreakEvents.AFTER.register((world, player, pos, state, blockEntity) -> {
+            protectedBreakAttempts.remove(BreakAttemptKey.block(player, world, pos));
+            dataManager.remove(ChestDataManager.createChestKey(world, pos));
         });
 
         // Register entity destroy interaction callback
@@ -115,11 +164,11 @@ public class LootRestock implements ModInitializer {
                         registerEntityInteraction(world, entity);
                     }
 
-                    // Drop the inventory contents naturally
-                    Containers.dropContents(world, chestMinecart.blockPosition(), chestMinecart.getItemStacks());
-                    
-                    // Prevent from actually breaking
-                    return InteractionResult.FAIL;
+                    BreakDecision decision = getBreakDecision(player);
+                    if (!decision.canBreak()) {
+                        sendActionBar(player, decision.message());
+                        return InteractionResult.FAIL;
+                    }
                 }
             }
 
@@ -168,6 +217,66 @@ public class LootRestock implements ModInitializer {
 
     private void onServerStop(MinecraftServer server) {
         LOGGER.info("Saving {} tracked chests", dataManager.getTrackedChestCount());
+        protectedBreakAttempts.clear();
         dataManager.save();
+    }
+
+    private boolean isRestockingContainer(Level world, BlockPos pos) {
+        return isRestockingContainer(world, pos, world.getBlockEntity(pos));
+    }
+
+    private boolean isRestockingContainer(Level world, BlockPos pos, BlockEntity blockEntity) {
+        if (!(blockEntity instanceof RandomizableContainerBlockEntity chestBlockEntity)) {
+            return false;
+        }
+
+        return dataManager.isTracked(world, pos) || chestBlockEntity.getLootTable() != null;
+    }
+
+    private boolean isRestockingMinecart(Level world, Entity entity) {
+        return entity instanceof MinecartChest chestMinecart
+                && (dataManager.isEntityTracked(world, entity.getStringUUID())
+                || chestMinecart.getContainerLootTable() != null);
+    }
+
+    private BreakDecision getBreakDecision(Player player) {
+        if (!hasChestBreakPermission(player)) {
+            return new BreakDecision(false, "This restocking chest is protected.");
+        }
+
+        if (config.requireCrouchToBreak() && !player.isShiftKeyDown()) {
+            return new BreakDecision(false, "Loot chest restocks. Sneak and hold to remove it.");
+        }
+
+        return new BreakDecision(true, "");
+    }
+
+    private boolean hasChestBreakPermission(Player player) {
+        return switch (config.getChestBreakingPermission()) {
+            case ANYONE -> true;
+            case OP_ONLY -> player.permissions().hasPermission(Permissions.COMMANDS_GAMEMASTER);
+            case NO_ONE -> false;
+        };
+    }
+
+    private String getRestockNotice() {
+        if (config.requireCrouchToBreak()) {
+            return "Loot chest restocks. Please leave it unless needed; sneak + hold to remove.";
+        }
+
+        return "Loot chest restocks. Please leave it in place unless you need to remove it.";
+    }
+
+    private void sendActionBar(Player player, String message) {
+        player.sendOverlayMessage(Component.literal(message));
+    }
+
+    private record BreakDecision(boolean canBreak, String message) {
+    }
+
+    private record BreakAttemptKey(UUID playerUuid, String chestKey) {
+        private static BreakAttemptKey block(Player player, Level world, BlockPos pos) {
+            return new BreakAttemptKey(player.getUUID(), ChestDataManager.createChestKey(world, pos));
+        }
     }
 }

--- a/src/main/java/org/oldskooler/lootrestock/config/ModConfig.java
+++ b/src/main/java/org/oldskooler/lootrestock/config/ModConfig.java
@@ -29,6 +29,8 @@ import java.util.Properties;
  *   <li><b>only_reset_when_empty</b>: true/false (default: true)</li>
  *   <li><b>include_barrels</b>: true/false (default: false)</li>
  *   <li><b>allow_chest_breaking</b>: Who can break chests - "op_only", "anyone", or "no_one" (default: op_only)</li>
+ *   <li><b>require_crouch_to_break</b>: true/false (default: true)</li>
+ *   <li><b>crouch_break_seconds</b>: Seconds players must keep breaking while crouched (default: 4)</li>
  * </ul>
  *
  * Notes:
@@ -44,16 +46,22 @@ public class ModConfig {
     private static final String CONFIG_ONLY_RESET_WHEN_EMPTY_KEY = "only_reset_when_empty";
     private static final String CONFIG_INCLUDE_BARRELS_KEY = "include_barrels";
     private static final String CONFIG_ALLOW_CHEST_BREAKING_KEY = "allow_chest_breaking";
+    private static final String CONFIG_REQUIRE_CROUCH_TO_BREAK_KEY = "require_crouch_to_break";
+    private static final String CONFIG_CROUCH_BREAK_SECONDS_KEY = "crouch_break_seconds";
 
     private static final long DEFAULT_RESET_TIME_VALUE = 7;
     private static final String DEFAULT_RESET_TIME_UNIT = "days";
     private static final boolean DEFAULT_ONLY_RESET_WHEN_EMPTY = true;
     private static final boolean DEFAULT_INCLUDE_BARRELS = false;
     private static final ChestBreakingPermission DEFAULT_CHEST_BREAKING = ChestBreakingPermission.OP_ONLY;
+    private static final boolean DEFAULT_REQUIRE_CROUCH_TO_BREAK = true;
+    private static final long DEFAULT_CROUCH_BREAK_SECONDS = 4;
 
     private boolean includeBarrels;
     private boolean onlyResetWhenEmpty;
     private ChestBreakingPermission chestBreakingPermission;
+    private boolean requireCrouchToBreak;
+    private long crouchBreakMs;
 
     // If cron is used, this flag is true and cronExpression contains the raw expression.
     private boolean useCron = false;
@@ -167,6 +175,12 @@ public class ModConfig {
                     config.getProperty(CONFIG_ALLOW_CHEST_BREAKING_KEY,
                             DEFAULT_CHEST_BREAKING.toString())
             );
+            requireCrouchToBreak = Boolean.parseBoolean(
+                    config.getProperty(CONFIG_REQUIRE_CROUCH_TO_BREAK_KEY,
+                            String.valueOf(DEFAULT_REQUIRE_CROUCH_TO_BREAK))
+            );
+            crouchBreakMs = parseCrouchBreakMs(config.getProperty(CONFIG_CROUCH_BREAK_SECONDS_KEY,
+                    String.valueOf(DEFAULT_CROUCH_BREAK_SECONDS)));
 
             LootRestock.LOGGER.info("'{}' = {}", CONFIG_TIME_VALUE_KEY,
                     config.getProperty(CONFIG_TIME_VALUE_KEY));
@@ -177,6 +191,8 @@ public class ModConfig {
             LootRestock.LOGGER.info("'{}' = {}", CONFIG_ONLY_RESET_WHEN_EMPTY_KEY, onlyResetWhenEmpty);
             LootRestock.LOGGER.info("'{}' = {}", CONFIG_INCLUDE_BARRELS_KEY, includeBarrels);
             LootRestock.LOGGER.info("'{}' = {}", CONFIG_ALLOW_CHEST_BREAKING_KEY, chestBreakingPermission);
+            LootRestock.LOGGER.info("'{}' = {}", CONFIG_REQUIRE_CROUCH_TO_BREAK_KEY, requireCrouchToBreak);
+            LootRestock.LOGGER.info("'{}' = {} ms", CONFIG_CROUCH_BREAK_SECONDS_KEY, crouchBreakMs);
         }
     }
 
@@ -228,6 +244,13 @@ public class ModConfig {
             sb.append("#   anyone   - Anyone can break chests\n");
             sb.append("#   no_one   - No one can break chests (fully protected)\n");
             sb.append(CONFIG_ALLOW_CHEST_BREAKING_KEY).append("=").append(DEFAULT_CHEST_BREAKING.toString()).append("\n");
+            sb.append("# \n");
+            sb.append("# Require players with break permission to crouch before removing a loot container?\n");
+            sb.append(CONFIG_REQUIRE_CROUCH_TO_BREAK_KEY).append("=").append(DEFAULT_REQUIRE_CROUCH_TO_BREAK).append("\n");
+            sb.append("# \n");
+            sb.append("# How long must a permitted player keep breaking while crouched?\n");
+            sb.append("# This makes accidental removal harder. Set to 0 for normal break speed.\n");
+            sb.append(CONFIG_CROUCH_BREAK_SECONDS_KEY).append("=").append(DEFAULT_CROUCH_BREAK_SECONDS).append("\n");
 
             out.write(sb.toString().getBytes());
         }
@@ -235,8 +258,24 @@ public class ModConfig {
         onlyResetWhenEmpty = DEFAULT_ONLY_RESET_WHEN_EMPTY;
         includeBarrels = DEFAULT_INCLUDE_BARRELS;
         chestBreakingPermission = DEFAULT_CHEST_BREAKING;
+        requireCrouchToBreak = DEFAULT_REQUIRE_CROUCH_TO_BREAK;
+        crouchBreakMs = DEFAULT_CROUCH_BREAK_SECONDS * 1000L;
         useCron = false;
         cronExpression = null;
+    }
+
+    private long parseCrouchBreakMs(String value) {
+        try {
+            long seconds = Long.parseLong(value);
+            if (seconds < 0) {
+                throw new IllegalArgumentException(CONFIG_CROUCH_BREAK_SECONDS_KEY + " must be 0 or greater");
+            }
+            return seconds * 1000L;
+        } catch (RuntimeException e) {
+            LootRestock.LOGGER.warn("Invalid '{}' value '{}'. Using default: {} seconds",
+                    CONFIG_CROUCH_BREAK_SECONDS_KEY, value, DEFAULT_CROUCH_BREAK_SECONDS);
+            return DEFAULT_CROUCH_BREAK_SECONDS * 1000L;
+        }
     }
 
     /**
@@ -295,6 +334,14 @@ public class ModConfig {
      */
     public ChestBreakingPermission getChestBreakingPermission() {
         return chestBreakingPermission;
+    }
+
+    public boolean requireCrouchToBreak() {
+        return requireCrouchToBreak;
+    }
+
+    public long getCrouchBreakMs() {
+        return crouchBreakMs;
     }
 
     /**

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
 	"schemaVersion": 1,
 	"id": "lootrestock",
-	"version": "1.0.0",
+	"version": "${version}",
 	"name": "Loot Restock",
 	"description": "A lightweight Fabric mod that automatically restocks loot chests after a configurable amount of time has passed.\n\n",
 	"authors": [
@@ -21,8 +21,8 @@
 	},
 	"mixins": [],
     "depends": {
-      "fabricloader": ">=0.18.4",
-      "minecraft": "~1.21.11",
+      "fabricloader": ">=0.19.3",
+      "minecraft": "~26.2",
       "java": ">=21",
       "fabric-api": "*"
     }


### PR DESCRIPTION
## Summary
- 26.2 port of LootRestock for the current Orlith target environment
- updates Gradle/Fabric dependency versions
- updates runtime code and config handling for the target API surface
- documents the 26.2 port status in the README

## Validation
- `bash ./gradlew build`
